### PR TITLE
Fix pinentry search order

### DIFF
--- a/pinentry/pinentry.go
+++ b/pinentry/pinentry.go
@@ -149,11 +149,11 @@ func FindPinentryGUIPath() string {
 	}
 
 	candidates := []string{
-		"pinentry-gnome3",
+		"pinentry",
+		"pinentry-gtk",
+		"pinentry-qt",
 		"pinentry-qt5",
 		"pinentry-qt4",
-		"pinentry-qt",
-		"pinentry-gtk-2",
 		"pinentry-x11",
 		"pinentry-fltk",
 	}


### PR DESCRIPTION
Fixes https://github.com/matejsmycka/linux-id/issues/14

/usr/bin/pinentry is a script that's provided at least on Fedora and Arch, which automatically detects desktop environment and launches respective pinentry handler. If it's not available, I changed the order of querying to be more sane (don't use older qt first and prefer pinentry-gtk, as it should be more universal.