### PR TITLE
feat: enhance fprintd behaviour

### DIFF
--- a/fprintd/fprintd.go
+++ b/fprintd/fprintd.go
@@ -61,38 +61,65 @@ func verifyFingerprint() error {
 	}
 
 	device := conn.Object("net.reactivated.Fprint", devices[0])
+
+	// This ensures we are "online" before the hardware triggers
+	if err := conn.AddMatchSignal(
+		dbus.WithMatchSender("net.reactivated.Fprint"),
+		dbus.WithMatchInterface("net.reactivated.Fprint.Device"),
+		dbus.WithMatchMember("VerifyStatus"),
+		dbus.WithMatchObjectPath(devices[0]), // Be specific to the device path
+	); err != nil {
+		return err
+	}
+
+	sigCh := make(chan *dbus.Signal, 10) // Buffer for multiple scan attempts
+	conn.Signal(sigCh)
+
 	if err := device.Call("net.reactivated.Fprint.Device.Claim", 0, "").Err; err != nil {
 		return err
 	}
 	defer device.Call("net.reactivated.Fprint.Device.Release", 0)
 
+	fmt.Println(">>> [Sensor Active] Please scan your finger...")
 	if err := device.Call("net.reactivated.Fprint.Device.VerifyStart", 0, "any").Err; err != nil {
 		return err
 	}
 	defer device.Call("net.reactivated.Fprint.Device.VerifyStop", 0)
 
-	if err := conn.AddMatchSignal(
-		dbus.WithMatchInterface("net.reactivated.Fprint.Device"),
-		dbus.WithMatchMember("VerifyStatus"),
-	); err != nil {
-		return err
-	}
-
-	sigCh := make(chan *dbus.Signal, 1)
-	conn.Signal(sigCh)
+	tryCount := 0
 
 	for {
 		select {
 		case sig := <-sigCh:
-			result := sig.Body[0].(string)
-			done := sig.Body[1].(bool)
-			if result == "verify-match" {
-				return nil
+			if len(sig.Body) < 2 {
+				continue
 			}
+
+			result, _ := sig.Body[0].(string)
+			done, _ := sig.Body[1].(bool)
+
 			if done {
-				return fmt.Errorf("fingerprint verification failed: %s", result)
+				if result == "verify-match" {
+					return nil
+				}
+
+				tryCount++
+				fmt.Printf(">>> [Scan Result] %s (Attempt %d/3)\n", result, tryCount)
+
+				if tryCount >= 3 {
+					return fmt.Errorf("fingerprint verification failed after %d attempts", tryCount)
+				}
+
+				// Reset the sensor
+				fmt.Println("Resetting sensor for next attempt...")
+				device.Call("net.reactivated.Fprint.Device.VerifyStop", 0)
+				time.Sleep(500 * time.Millisecond)
+
+				if err := device.Call("net.reactivated.Fprint.Device.VerifyStart", 0, "any").Err; err != nil {
+					return fmt.Errorf("failed to restart: %w", err)
+				}
 			}
-			// non-terminal status (e.g. "verify-retry-scan") — keep waiting
+
 		case <-time.After(30 * time.Second):
 			return fmt.Errorf("fingerprint verification timed out")
 		}

--- a/main.go
+++ b/main.go
@@ -228,42 +228,29 @@ func (s *server) handleAuthenticate(parentCtx context.Context, token *fidohid.So
 	var userPresent uint8
 
 	if req.Authenticate.Ctrl == fidoauth.CtrlEnforeUserPresenceAndSign {
-
-		pinResultCh, err := s.pe.ConfirmPresence("FIDO Confirm Auth", req.Authenticate.ChallengeParam, req.Authenticate.ApplicationParam)
-
+		resultCh, err := s.verifier.VerifyUser("FIDO Confirm Auth")
 		if err != nil {
-			log.Printf("pinentry err: %s", err)
+			log.Printf("verification trigger err: %s", err)
 			token.WriteResponse(parentCtx, evt, nil, statuscode.ConditionsNotSatisfied)
-
 			return
 		}
 
-		childCtx, cancel := context.WithTimeout(parentCtx, 750*time.Millisecond)
+		childCtx, cancel := context.WithTimeout(parentCtx, 30*time.Second)
 		defer cancel()
 
 		select {
-		case result := <-pinResultCh:
+		case result := <-resultCh:
 			if result.OK {
 				userPresent = 0x01
 			} else {
 				if result.Error != nil {
-					log.Printf("Got pinentry result err: %s", result.Error)
+					log.Printf("Got verification result err: %s", result.Error)
 				}
-
-				// Got user cancelation, we want to propagate that so the browser gives up.
-				// This isn't normally supported by a key so there's no status code for this.
-				// WrongData seems like the least incorrect status code ¯\_(ツ)_/¯
-				err := token.WriteResponse(parentCtx, evt, nil, statuscode.WrongData)
-				if err != nil {
-					log.Printf("Write WrongData resp err: %s", err)
-				}
+				token.WriteResponse(parentCtx, evt, nil, statuscode.WrongData)
 				return
 			}
 		case <-childCtx.Done():
-			err := token.WriteResponse(parentCtx, evt, nil, statuscode.ConditionsNotSatisfied)
-			if err != nil {
-				log.Printf("Write swConditionsNotSatisfied resp err: %s", err)
-			}
+			token.WriteResponse(parentCtx, evt, nil, statuscode.ConditionsNotSatisfied)
 			return
 		}
 	}
@@ -645,26 +632,28 @@ func (s *server) handleGetAssertion(ctx context.Context, token *fidohid.SoftToke
 		keyHandle = storedCred.CredID
 	}
 
-	resultCh, err := s.verifier.VerifyUser("FIDO2 Authenticate: " + req.RPID)
-	if err != nil {
-		log.Printf("GetAssertion verifier err: %s", err)
-		token.WriteCtap2Response(ctx, evt, ctap2.StatusOperationDenied, nil)
-		return
-	}
-	childCtx, cancel := context.WithTimeout(ctx, 35*time.Second)
-	defer cancel()
-	select {
-	case result := <-resultCh:
-		if !result.OK {
-			if result.Error != nil {
-				log.Printf("GetAssertion verifier result err: %s", result.Error)
-			}
+	if req.Options.UV {
+		resultCh, err := s.verifier.VerifyUser("FIDO2 Authenticate: " + req.RPID)
+		if err != nil {
+			log.Printf("GetAssertion verifier err: %s", err)
 			token.WriteCtap2Response(ctx, evt, ctap2.StatusOperationDenied, nil)
 			return
 		}
-	case <-childCtx.Done():
-		token.WriteCtap2Response(ctx, evt, ctap2.StatusUserActionTimeout, nil)
-		return
+		childCtx, cancel := context.WithTimeout(ctx, 35*time.Second)
+		defer cancel()
+		select {
+		case result := <-resultCh:
+			if !result.OK {
+				if result.Error != nil {
+					log.Printf("GetAssertion verifier result err: %s", result.Error)
+				}
+				token.WriteCtap2Response(ctx, evt, ctap2.StatusOperationDenied, nil)
+				return
+			}
+		case <-childCtx.Done():
+			token.WriteCtap2Response(ctx, evt, ctap2.StatusUserActionTimeout, nil)
+			return
+		}
 	}
 
 	// authenticatorData: rpIdHash(32) | flags(1) | signCount(4)
@@ -699,13 +688,18 @@ func (s *server) handleGetAssertion(ctx context.Context, token *fidohid.SoftToke
 		3: sig,
 	}
 	if storedCred != nil {
-		response[4] = map[string]interface{}{
-			"id":          storedCred.UserID,
-			"name":        storedCred.UserName,
-			"displayName": storedCred.DisplayName,
+		response[4] = map[int]interface{}{
+			1: storedCred.UserID,
+			2: storedCred.UserName,
+			3: storedCred.DisplayName,
 		}
 	}
-	encoded, err := cbor.Marshal(response)
+	// Create a CTAP2-compliant encoder options
+	opts := cbor.CanonicalEncOptions() // This ensures sorting 1, 2, 3...
+	em, _ := opts.EncMode()
+
+	// Use the encoder mode to marshal
+	encoded, err := em.Marshal(response)
 	if err != nil {
 		log.Printf("GetAssertion response marshal err: %s", err)
 		token.WriteCtap2Response(ctx, evt, ctap2.StatusOperationDenied, nil)
@@ -715,5 +709,3 @@ func (s *server) handleGetAssertion(ctx context.Context, token *fidohid.SoftToke
 	log.Printf("GetAssertion ok: rp=%s", req.RPID)
 	token.WriteCtap2Response(ctx, evt, ctap2.StatusOK, encoded)
 }
-
-


### PR DESCRIPTION
I forked my own branch and made this work, but I just wanna give it back to the community. What this PR does:
- Reorder logic to avoid a race condition when triggering the fingerprint scanner
- Fingerprint retry logic (3 times)
- (Opinionated): Trigger user verification (fingerprint scan) even when it's a U2F request. This is because browsers sometimes fall back to U2F when FIDO2 fails.
- Fix: Wrong response schema for FIDO2 authentication, causing the browser to ignore it.
- Fix: Increase timeout for verify user (at least that's what I believe cause it works for me). Before that, the timeout is too fast (750ms), which makes it impossible to reach the fingerprint sensor.

Tested on NixOS (with `--auth fprintd`)