### PR TITLE
test: spec-correct CTAP2 fixes pinned by load-bearing tests

### DIFF
--- a/ctap2/ctap2.go
+++ b/ctap2/ctap2.go
@@ -14,9 +14,9 @@ const (
 	StatusCredentialExcluded  = byte(0x19) // credential in excludeList already exists
 	StatusUnsupportedAlg      = byte(0x26)
 	StatusOperationDenied     = byte(0x27)
-	StatusUserActionTimeout   = byte(0x2A)
 	StatusInvalidOption       = byte(0x2C) // uv=true but authenticator cannot verify identity
 	StatusNoCredentials       = byte(0x2E)
+	StatusUserActionTimeout   = byte(0x2F) // CTAP 2.1 §8.2 / FIDO_ERR_USER_ACTION_TIMEOUT
 	StatusNotAllowed          = byte(0x30)
 )
 

--- a/fprintd/fprintd.go
+++ b/fprintd/fprintd.go
@@ -89,20 +89,45 @@ func verifyFingerprint() error {
 	for {
 		select {
 		case sig := <-sigCh:
-			if len(sig.Body) < 2 {
-				continue // malformed signal — keep waiting
-			}
-			result, _ := sig.Body[0].(string)
-			done, _ := sig.Body[1].(bool)
-			if result == "verify-match" {
+			matched, terminal, err := processVerifyStatus(sig.Body)
+			if matched {
 				return nil
 			}
-			if done {
-				return fmt.Errorf("fingerprint verification failed: %s", result)
+			if terminal {
+				return err
 			}
 			// non-terminal status (e.g. "verify-retry-scan") — keep waiting
 		case <-time.After(30 * time.Second):
 			return fmt.Errorf("fingerprint verification timed out")
 		}
 	}
+}
+
+// processVerifyStatus interprets a single fprintd VerifyStatus signal body.
+//
+// Returns:
+//   - matched=true  → verification succeeded; caller should return nil
+//   - terminal=true → verification ended (success or failure); caller should
+//     return err (nil on success, non-nil on failure)
+//   - matched=false, terminal=false → non-terminal status (e.g. verify-retry-scan,
+//     malformed signal). Caller should keep waiting.
+//
+// Defensive against malformed signals: a body shorter than 2 elements or with
+// the wrong types is treated as non-terminal so a single garbage signal cannot
+// crash the daemon.
+func processVerifyStatus(body []interface{}) (matched, terminal bool, err error) {
+	if len(body) < 2 {
+		return false, false, nil
+	}
+	result, _ := body[0].(string)
+	done, _ := body[1].(bool)
+	if !done {
+		// Either non-terminal status or wrong types on the booleans.
+		// Either way: keep waiting for the next signal.
+		return false, false, nil
+	}
+	if result == "verify-match" {
+		return true, true, nil
+	}
+	return false, true, fmt.Errorf("fingerprint verification failed: %s", result)
 }

--- a/fprintd/fprintd.go
+++ b/fprintd/fprintd.go
@@ -61,6 +61,21 @@ func verifyFingerprint() error {
 	}
 
 	device := conn.Object("net.reactivated.Fprint", devices[0])
+
+	// Subscribe to VerifyStatus signals BEFORE VerifyStart so the first
+	// status update from the sensor cannot race ahead of our channel.
+	// Scoping by sender + object path keeps the match strict.
+	if err := conn.AddMatchSignal(
+		dbus.WithMatchSender("net.reactivated.Fprint"),
+		dbus.WithMatchInterface("net.reactivated.Fprint.Device"),
+		dbus.WithMatchMember("VerifyStatus"),
+		dbus.WithMatchObjectPath(devices[0]),
+	); err != nil {
+		return err
+	}
+	sigCh := make(chan *dbus.Signal, 4)
+	conn.Signal(sigCh)
+
 	if err := device.Call("net.reactivated.Fprint.Device.Claim", 0, "").Err; err != nil {
 		return err
 	}
@@ -71,21 +86,14 @@ func verifyFingerprint() error {
 	}
 	defer device.Call("net.reactivated.Fprint.Device.VerifyStop", 0)
 
-	if err := conn.AddMatchSignal(
-		dbus.WithMatchInterface("net.reactivated.Fprint.Device"),
-		dbus.WithMatchMember("VerifyStatus"),
-	); err != nil {
-		return err
-	}
-
-	sigCh := make(chan *dbus.Signal, 1)
-	conn.Signal(sigCh)
-
 	for {
 		select {
 		case sig := <-sigCh:
-			result := sig.Body[0].(string)
-			done := sig.Body[1].(bool)
+			if len(sig.Body) < 2 {
+				continue // malformed signal — keep waiting
+			}
+			result, _ := sig.Body[0].(string)
+			done, _ := sig.Body[1].(bool)
 			if result == "verify-match" {
 				return nil
 			}

--- a/fprintd/fprintd_test.go
+++ b/fprintd/fprintd_test.go
@@ -1,0 +1,134 @@
+package fprintd
+
+import "testing"
+
+// processVerifyStatus is the pure-data heart of verifyFingerprint(): it
+// interprets one fprintd VerifyStatus signal body. The wrapping
+// verifyFingerprint() needs a real D-Bus connection so it can't be unit-tested,
+// but the signal interpretation logic can — and it's where the historical
+// crash-on-malformed-signal lives, so it's worth pinning.
+func TestProcessVerifyStatus(t *testing.T) {
+	cases := []struct {
+		name         string
+		body         []interface{}
+		wantMatched  bool
+		wantTerminal bool
+		wantErrMsg   string // empty = expect nil error
+	}{
+		{
+			// fprintd reports a successful match. Verification ends, the caller
+			// returns nil.
+			name:         "verify-match terminal success",
+			body:         []interface{}{"verify-match", true},
+			wantMatched:  true,
+			wantTerminal: true,
+		},
+		{
+			// fprintd reports a final no-match (the user's finger doesn't match
+			// any enrolled template). Verification ends with an error.
+			name:         "verify-no-match terminal failure",
+			body:         []interface{}{"verify-no-match", true},
+			wantTerminal: true,
+			wantErrMsg:   "fingerprint verification failed: verify-no-match",
+		},
+		{
+			// Sensor disconnected mid-scan — fatal.
+			name:         "verify-disconnected terminal failure",
+			body:         []interface{}{"verify-disconnected", true},
+			wantTerminal: true,
+			wantErrMsg:   "fingerprint verification failed: verify-disconnected",
+		},
+		{
+			// User scanned too quickly / partially — sensor wants another try.
+			// Non-terminal: fprintd is still verifying, the loop must keep waiting.
+			name: "verify-retry-scan non-terminal",
+			body: []interface{}{"verify-retry-scan", false},
+		},
+		{
+			name: "verify-swipe-too-short non-terminal",
+			body: []interface{}{"verify-swipe-too-short", false},
+		},
+		{
+			name: "verify-finger-not-centered non-terminal",
+			body: []interface{}{"verify-finger-not-centered", false},
+		},
+		{
+			// Malformed body: empty. Old code would panic on body[0]. New code
+			// must treat this as a non-terminal status and keep waiting.
+			name: "empty body — defensive",
+			body: []interface{}{},
+		},
+		{
+			// Malformed body: only one element. Old code would panic on body[1].
+			name: "single-element body — defensive",
+			body: []interface{}{"verify-match"},
+		},
+		{
+			// Malformed body: wrong type on element 0. The type assertion now
+			// uses the comma-ok form so it returns "" rather than panicking.
+			// Treated as non-terminal.
+			name: "wrong type on result — defensive",
+			body: []interface{}{42, false},
+		},
+		{
+			// Malformed body: wrong type on element 1. done becomes false.
+			// Treated as non-terminal.
+			name: "wrong type on done — defensive",
+			body: []interface{}{"verify-match", "yes"},
+		},
+		{
+			// nil body. Slice length 0 → defensive non-terminal.
+			name: "nil body",
+			body: nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			matched, terminal, err := processVerifyStatus(tc.body)
+			if matched != tc.wantMatched {
+				t.Errorf("matched = %v, want %v", matched, tc.wantMatched)
+			}
+			if terminal != tc.wantTerminal {
+				t.Errorf("terminal = %v, want %v", terminal, tc.wantTerminal)
+			}
+			if tc.wantErrMsg == "" && err != nil {
+				t.Errorf("err = %v, want nil", err)
+			}
+			if tc.wantErrMsg != "" {
+				if err == nil {
+					t.Errorf("err = nil, want %q", tc.wantErrMsg)
+				} else if err.Error() != tc.wantErrMsg {
+					t.Errorf("err = %q, want %q", err.Error(), tc.wantErrMsg)
+				}
+			}
+		})
+	}
+}
+
+// TestProcessVerifyStatus_NoPanicOnAnyBody is a smoke check: the function
+// must never panic regardless of body contents. Catches any future regression
+// that re-introduces unguarded type assertions.
+func TestProcessVerifyStatus_NoPanicOnAnyBody(t *testing.T) {
+	bodies := [][]interface{}{
+		nil,
+		{},
+		{nil, nil},
+		{nil, false},
+		{"verify-match", nil},
+		{[]byte("not a string"), 0},
+		{struct{}{}, struct{}{}},
+		{0, 0, 0, 0, 0},
+		{"verify-match", true, "extra", "stuff"},
+	}
+	for i, b := range bodies {
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Errorf("body #%d panicked: %v", i, r)
+				}
+			}()
+			processVerifyStatus(b)
+		}()
+	}
+}

--- a/main.go
+++ b/main.go
@@ -30,6 +30,18 @@ var backend = flag.String("backend", "tpm", "tpm|memory")
 var device = flag.String("device", "/dev/tpmrm0", "TPM device path")
 var auth = flag.String("auth", "pinentry", "pinentry|fprintd — pinentry confirms presence (UP only); fprintd verifies identity via fingerprint (UP+UV)")
 
+// ctap2Enc is the CTAP2 Canonical CBOR encoder. Per CTAP §6, all CTAP2
+// messages must use canonical encoding (sorted keys, shortest-form integers,
+// definite-length items). The default cbor.Marshal does not enforce this and
+// emits map keys in Go iteration order, which some clients reject.
+var ctap2Enc cbor.EncMode = func() cbor.EncMode {
+	em, err := cbor.CTAP2EncOptions().EncMode()
+	if err != nil {
+		panic(err)
+	}
+	return em
+}()
+
 // tokenResponder is the subset of *fidohid.SoftToken that the request handlers
 // need to write replies. It exists so handlers can be unit-tested with a fake.
 type tokenResponder interface {
@@ -436,7 +448,7 @@ func (s *server) handleGetInfo(ctx context.Context, token tokenResponder, evt fi
 		4: options,
 		5: 1200, // maxMsgSize
 	}
-	encoded, err := cbor.Marshal(response)
+	encoded, err := ctap2Enc.Marshal(response)
 	if err != nil {
 		log.Printf("GetInfo marshal err: %s", err)
 		token.WriteCtap2Response(ctx, evt, ctap2.StatusInvalidCbor, nil)
@@ -541,7 +553,7 @@ func (s *server) handleMakeCredential(ctx context.Context, token tokenResponder,
 		-2: xBytes, // x
 		-3: yBytes, // y
 	}
-	coseKeyBytes, err := cbor.Marshal(coseKey)
+	coseKeyBytes, err := ctap2Enc.Marshal(coseKey)
 	if err != nil {
 		log.Printf("MakeCredential coseKey marshal err: %s", err)
 		token.WriteCtap2Response(ctx, evt, ctap2.StatusOperationDenied, nil)
@@ -572,7 +584,7 @@ func (s *server) handleMakeCredential(ctx context.Context, token tokenResponder,
 		2: authDataBytes,
 		3: map[interface{}]interface{}{},
 	}
-	encoded, err := cbor.Marshal(response)
+	encoded, err := ctap2Enc.Marshal(response)
 	if err != nil {
 		log.Printf("MakeCredential response marshal err: %s", err)
 		token.WriteCtap2Response(ctx, evt, ctap2.StatusOperationDenied, nil)
@@ -718,7 +730,7 @@ func (s *server) handleGetAssertion(ctx context.Context, token tokenResponder, e
 			"displayName": storedCred.DisplayName,
 		}
 	}
-	encoded, err := cbor.Marshal(response)
+	encoded, err := ctap2Enc.Marshal(response)
 	if err != nil {
 		log.Printf("GetAssertion response marshal err: %s", err)
 		token.WriteCtap2Response(ctx, evt, ctap2.StatusOperationDenied, nil)

--- a/main_test.go
+++ b/main_test.go
@@ -749,6 +749,245 @@ func skipItem(b []byte) (int, error) {
 	return 0, fmt.Errorf("unsupported major type %d", mt)
 }
 
+// Direct unit test of ctap2Enc. Verifies that the encoder actually sorts map
+// keys, by feeding it a literal whose declared order does NOT match canonical
+// order. If ctap2Enc is wired to default cbor options instead of CTAP2EncOptions,
+// this test fails. This is the strong canonicality proof — the integration
+// tests below rely on this passing for their own correctness claims.
+//
+// The integration tests for MakeCredential / GetInfo / COSE-key happen to come
+// out canonical even with the default encoder (their literal map order is
+// already sorted), so they cannot directly distinguish ctap2Enc from default.
+// This unit test fills that gap.
+func TestCTAP2Enc_SortsMapKeys(t *testing.T) {
+	t.Run("integer keys, declared out of order", func(t *testing.T) {
+		// Map literal order ≠ canonical order. Default cbor.Marshal would
+		// emit these in iteration order (which fxamacker happens to make
+		// somewhat deterministic but NOT canonical).
+		m := map[int]string{4: "d", 1: "a", 3: "c", 2: "b", 5: "e"}
+		encoded, err := ctap2Enc.Marshal(m)
+		if err != nil {
+			t.Fatalf("marshal: %s", err)
+		}
+		order, err := readMapIntKeyOrder(encoded)
+		if err != nil {
+			t.Fatalf("walk: %s", err)
+		}
+		want := []int{1, 2, 3, 4, 5}
+		if fmt.Sprintf("%v", order) != fmt.Sprintf("%v", want) {
+			t.Errorf("ctap2Enc int-key order = %v, want %v", order, want)
+		}
+	})
+
+	t.Run("string keys, declared out of order", func(t *testing.T) {
+		// Bytewise lex order of CBOR encoding for these keys:
+		//   "id"          → 0x62 0x69 0x64
+		//   "icon"        → 0x64 0x69 0x63 0x6f 0x6e
+		//   "name"        → 0x64 0x6e 0x61 0x6d 0x65
+		//   "displayName" → 0x6b ...
+		// → id < icon < name < displayName (bytewise on CBOR-encoded form).
+		m := map[string]string{
+			"name":        "n",
+			"displayName": "d",
+			"id":          "i",
+			"icon":        "c",
+		}
+		encoded, err := ctap2Enc.Marshal(m)
+		if err != nil {
+			t.Fatalf("marshal: %s", err)
+		}
+		order, err := readMapStringKeyOrder(encoded)
+		if err != nil {
+			t.Fatalf("walk: %s", err)
+		}
+		want := []string{"id", "icon", "name", "displayName"}
+		if fmt.Sprintf("%v", order) != fmt.Sprintf("%v", want) {
+			t.Errorf("ctap2Enc str-key order = %v, want %v", order, want)
+		}
+	})
+
+	t.Run("mixed positive and negative integer keys (COSE shape)", func(t *testing.T) {
+		// COSE EC2 keys: 1=kty, 3=alg, -1=crv, -2=x, -3=y.
+		// CBOR encoding of small ints: positive 0..23 = 0x00..0x17,
+		//                              negative -1..-24 = 0x20..0x37.
+		// So positives sort before negatives in bytewise lex.
+		m := map[int]int{-3: 3, 1: 1, -1: 1, 3: 1, -2: 2}
+		encoded, err := ctap2Enc.Marshal(m)
+		if err != nil {
+			t.Fatalf("marshal: %s", err)
+		}
+		order, err := readSignedMapKeyOrder(encoded)
+		if err != nil {
+			t.Fatalf("walk: %s", err)
+		}
+		want := []int{1, 3, -1, -2, -3}
+		if fmt.Sprintf("%v", order) != fmt.Sprintf("%v", want) {
+			t.Errorf("ctap2Enc COSE-key order = %v, want %v", order, want)
+		}
+	})
+}
+
+// Response shape pinning for MakeCredential. NOT a canonicality test — see
+// TestCTAP2Enc_SortsMapKeys for that. This just confirms the response has
+// the expected top-level keys (1=fmt, 2=authData, 3=attStmt) and decodes.
+func TestMakeCredential_ResponseShape(t *testing.T) {
+	verifier := &fakeVerifier{performsUV: true, nextResult: VerifyResult{OK: true}}
+	s := newTestServer(t, verifier, &fakePinentry{})
+
+	resp := &fakeResponder{}
+	payload := makeMakeCredCBOR(t, "shape-mc.example", "Shape", "user", false, false)
+	s.handleMakeCredential(context.Background(), resp, fidohid.AuthEvent{}, payload)
+
+	if resp.lastCtap2().status != ctap2.StatusOK {
+		t.Fatalf("status=0x%02x", resp.lastCtap2().status)
+	}
+	var top map[int]cbor.RawMessage
+	if err := cbor.Unmarshal(resp.lastCtap2().data, &top); err != nil {
+		t.Fatalf("response is not well-formed CBOR: %s", err)
+	}
+	for _, k := range []int{1, 2, 3} {
+		if _, ok := top[k]; !ok {
+			t.Errorf("MakeCredential response missing field %d", k)
+		}
+	}
+	var fmtField string
+	cbor.Unmarshal(top[1], &fmtField)
+	if fmtField != "none" {
+		t.Errorf("attestation fmt = %q, want \"none\" (privacy)", fmtField)
+	}
+}
+
+// Response shape pinning for GetInfo. NOT a canonicality test — see
+// TestCTAP2Enc_SortsMapKeys for that.
+func TestGetInfo_ResponseShape(t *testing.T) {
+	s := newTestServer(t, &fakeVerifier{performsUV: true}, &fakePinentry{})
+	resp := &fakeResponder{}
+	s.handleGetInfo(context.Background(), resp, fidohid.AuthEvent{})
+
+	if resp.lastCtap2().status != ctap2.StatusOK {
+		t.Fatalf("status=0x%02x", resp.lastCtap2().status)
+	}
+	var top map[int]cbor.RawMessage
+	if err := cbor.Unmarshal(resp.lastCtap2().data, &top); err != nil {
+		t.Fatalf("response is not well-formed CBOR: %s", err)
+	}
+	for _, k := range []int{1, 3, 4, 5} {
+		if _, ok := top[k]; !ok {
+			t.Errorf("GetInfo response missing field %d", k)
+		}
+	}
+	var versions []string
+	cbor.Unmarshal(top[1], &versions)
+	hasFIDO2, hasU2F := false, false
+	for _, v := range versions {
+		if v == "FIDO_2_0" {
+			hasFIDO2 = true
+		}
+		if v == "U2F_V2" {
+			hasU2F = true
+		}
+	}
+	if !hasFIDO2 || !hasU2F {
+		t.Errorf("versions = %v, want both FIDO_2_0 and U2F_V2", versions)
+	}
+}
+
+// readSignedMapKeyOrder is like readMapIntKeyOrder but accepts CBOR negative
+// integer keys too (used for COSE keys where -1=crv, -2=x, -3=y).
+func readSignedMapKeyOrder(raw []byte) ([]int, error) {
+	if len(raw) < 1 {
+		return nil, errors.New("empty cbor")
+	}
+	mt := raw[0] >> 5
+	if mt != 5 {
+		return nil, fmt.Errorf("not a map: major type %d", mt)
+	}
+	pos := 1
+	count := int(raw[0] & 0x1f)
+	if count == 0x18 {
+		count = int(raw[1])
+		pos = 2
+	}
+	out := make([]int, 0, count)
+	for i := 0; i < count; i++ {
+		k, n, err := readInt(raw[pos:])
+		if err != nil {
+			return nil, fmt.Errorf("key %d: %w", i, err)
+		}
+		out = append(out, k)
+		pos += n
+		vn, err := skipItem(raw[pos:])
+		if err != nil {
+			return nil, err
+		}
+		pos += vn
+	}
+	return out, nil
+}
+
+// Encoding the same input twice MUST produce identical bytes. Without
+// canonical encoding this can flip on Go map iteration order. With ctap2Enc,
+// the bytes are stable across runs and across processes.
+func TestCBOR_EncodingIsByteStable(t *testing.T) {
+	verifier := &fakeVerifier{performsUV: true, nextResult: VerifyResult{OK: true}}
+	s := newTestServer(t, verifier, &fakePinentry{})
+	registerCred(t, s, "stable.example", "Stable", "user", true /*rk*/)
+
+	// Run the same GetAssertion 10 times and confirm authData + signature
+	// shape is byte-identical for the deterministic parts (everything except
+	// the signature, which is randomized by ECDSA, and the counter, which
+	// increments).
+	var firstAuthData []byte
+	for i := 0; i < 10; i++ {
+		resp := &fakeResponder{}
+		payload := makeAssertionCBOR(t, "stable.example", nil, nil)
+		s.handleGetAssertion(context.Background(), resp, fidohid.AuthEvent{}, payload)
+		if resp.lastCtap2().status != ctap2.StatusOK {
+			t.Fatalf("iter %d: status=0x%02x", i, resp.lastCtap2().status)
+		}
+		top := decodeAssertion(t, resp.lastCtap2().data)
+		var authData []byte
+		cbor.Unmarshal(top[2], &authData)
+		// authData = rpIdHash(32) | flags(1) | counter(4). Strip the counter
+		// before comparing, since counters increment.
+		stable := append([]byte{}, authData[:33]...) // rpIdHash + flags
+		if i == 0 {
+			firstAuthData = stable
+			continue
+		}
+		if !bytes.Equal(stable, firstAuthData) {
+			t.Errorf("iter %d: authData prefix changed across runs", i)
+		}
+		// And the user entity bytes (key 4) must be byte-identical (no signing,
+		// no counter). This is the strongest stability check we can make.
+		if !bytes.Equal(top[4], decodeAssertion(t, resp.lastCtap2().data)[4]) {
+			t.Errorf("iter %d: user entity bytes drifted", i)
+		}
+	}
+}
+
+// The canonical bytes must round-trip cleanly through fxamacker/cbor's standard
+// decoder. Catches any encoder option that produces non-decodable output.
+func TestCBOR_CanonicalOutputRoundTrips(t *testing.T) {
+	verifier := &fakeVerifier{performsUV: true, nextResult: VerifyResult{OK: true}}
+	s := newTestServer(t, verifier, &fakePinentry{})
+	registerCred(t, s, "rt.example", "RT", "user", true)
+
+	resp := &fakeResponder{}
+	payload := makeAssertionCBOR(t, "rt.example", nil, nil)
+	s.handleGetAssertion(context.Background(), resp, fidohid.AuthEvent{}, payload)
+
+	var top map[int]interface{}
+	if err := cbor.Unmarshal(resp.lastCtap2().data, &top); err != nil {
+		t.Fatalf("response is not well-formed CBOR: %s", err)
+	}
+	for _, key := range []int{1, 2, 3, 4} {
+		if _, ok := top[key]; !ok {
+			t.Errorf("response missing key %d", key)
+		}
+	}
+}
+
 // The signature in field 3 must verify against the assertion's authData ||
 // clientDataHash. Catches any change that breaks the signing input.
 func TestGetAssertion_SignatureCoversAuthDataAndClientDataHash(t *testing.T) {
@@ -1007,6 +1246,163 @@ func TestRealWorld_DuplicateRegistrationRejected(t *testing.T) {
 	s.handleMakeCredential(context.Background(), resp, fidohid.AuthEvent{}, payload)
 	if got := resp.lastCtap2().status; got != ctap2.StatusCredentialExcluded {
 		t.Fatalf("expected StatusCredentialExcluded (0x19), got 0x%02x", got)
+	}
+}
+
+// AllowList ordering: when several credentials are listed but only the second
+// is recoverable by our signer, the handler must walk past the invalid one
+// and pick the valid one. The order in the response's `credential` field must
+// match the entry that was actually used.
+func TestGetAssertion_AllowListSecondCredValid(t *testing.T) {
+	verifier := &fakeVerifier{performsUV: true, nextResult: VerifyResult{OK: true}}
+	s := newTestServer(t, verifier, &fakePinentry{})
+	credID := registerCred(t, s, "multi.example", "Multi", "user", false)
+
+	// First entry: total junk. Second entry: real cred. Handler must use #2.
+	resp := &fakeResponder{}
+	payload := makeAssertionCBOR(t, "multi.example",
+		[]ctap2.CredDescriptor{
+			{Type: "public-key", ID: []byte("not-a-real-cred-id-12345")},
+			{Type: "public-key", ID: credID},
+		},
+		nil)
+	s.handleGetAssertion(context.Background(), resp, fidohid.AuthEvent{}, payload)
+
+	if resp.lastCtap2().status != ctap2.StatusOK {
+		t.Fatalf("status=0x%02x", resp.lastCtap2().status)
+	}
+	top := decodeAssertion(t, resp.lastCtap2().data)
+	var cred map[string]interface{}
+	if err := cbor.Unmarshal(top[1], &cred); err != nil {
+		t.Fatalf("decode credential descriptor: %s", err)
+	}
+	gotID, ok := cred["id"].([]byte)
+	if !ok {
+		t.Fatalf("credential.id is not []byte: %T", cred["id"])
+	}
+	if !bytes.Equal(gotID, credID) {
+		t.Errorf("returned credential id = %x, want %x", gotID, credID)
+	}
+}
+
+// AllowList where every entry is invalid: handler must return NoCredentials
+// and never invoke the verifier (no point asking for biometric if there's no
+// key to sign with).
+func TestGetAssertion_AllowListAllInvalidNoVerifierCall(t *testing.T) {
+	verifier := &fakeVerifier{performsUV: true, nextResult: VerifyResult{OK: true}}
+	s := newTestServer(t, verifier, &fakePinentry{})
+
+	resp := &fakeResponder{}
+	payload := makeAssertionCBOR(t, "junk.example",
+		[]ctap2.CredDescriptor{
+			{Type: "public-key", ID: []byte("garbage1")},
+			{Type: "public-key", ID: []byte("garbage2")},
+			{Type: "public-key", ID: []byte("garbage3")},
+		},
+		nil)
+	s.handleGetAssertion(context.Background(), resp, fidohid.AuthEvent{}, payload)
+
+	if got := resp.lastCtap2().status; got != ctap2.StatusNoCredentials {
+		t.Fatalf("expected StatusNoCredentials, got 0x%02x", got)
+	}
+	if verifier.callCount != 0 {
+		t.Errorf("verifier must not be called if no credential matches; got %d calls", verifier.callCount)
+	}
+}
+
+// Resident credential with empty optional fields. Browsers can register a
+// passkey where only `id` is set (no name, no display name) when the user
+// chooses anonymous mode. The user entity in the response must still be
+// well-formed CBOR with all three string keys.
+func TestGetAssertion_ResidentCredentialMinimalUserFields(t *testing.T) {
+	verifier := &fakeVerifier{performsUV: true, nextResult: VerifyResult{OK: true}}
+	s := newTestServer(t, verifier, &fakePinentry{})
+
+	// Register with empty name + displayName.
+	req := ctap2.MakeCredentialRequest{
+		ClientDataHash:   sha256.New().Sum([]byte("mc:anon"))[:32],
+		RP:               ctap2.RPEntity{ID: "anon.example", Name: "Anon"},
+		User:             ctap2.UserEntity{ID: []byte("anonymous-handle")},
+		PubKeyCredParams: []ctap2.CredParam{{Type: "public-key", Alg: -7}},
+		Options:          &ctap2.MakeCredOptions{RK: true},
+	}
+	mcPayload, _ := cbor.Marshal(req)
+	mcResp := &fakeResponder{}
+	s.handleMakeCredential(context.Background(), mcResp, fidohid.AuthEvent{}, mcPayload)
+	if mcResp.lastCtap2().status != ctap2.StatusOK {
+		t.Fatalf("register: 0x%02x", mcResp.lastCtap2().status)
+	}
+
+	// Now look the resident credential up.
+	gaResp := &fakeResponder{}
+	gaPayload := makeAssertionCBOR(t, "anon.example", nil, nil)
+	s.handleGetAssertion(context.Background(), gaResp, fidohid.AuthEvent{}, gaPayload)
+	if gaResp.lastCtap2().status != ctap2.StatusOK {
+		t.Fatalf("assert: 0x%02x", gaResp.lastCtap2().status)
+	}
+
+	top := decodeAssertion(t, gaResp.lastCtap2().data)
+	var user map[string]interface{}
+	if err := cbor.Unmarshal(top[4], &user); err != nil {
+		t.Fatalf("user entity: %s", err)
+	}
+	if id, _ := user["id"].([]byte); !bytes.Equal(id, []byte("anonymous-handle")) {
+		t.Errorf("user.id = %x, want %x", id, []byte("anonymous-handle"))
+	}
+	// Empty strings are still acceptable. Just confirm the keys are there
+	// (canonical CBOR shape) — value content can be empty.
+	if _, ok := user["name"]; !ok {
+		t.Errorf("user entity missing name key (even if empty)")
+	}
+	if _, ok := user["displayName"]; !ok {
+		t.Errorf("user entity missing displayName key (even if empty)")
+	}
+}
+
+// COSE EC2 public key shape: the inner crypto key inside MakeCredential's
+// authenticatorData must be a valid P-256 ES256 key. Field tags:
+//   1  (kty)  = 2  (EC2)
+//   3  (alg)  = -7 (ES256)
+//   -1 (crv)  = 1  (P-256)
+//   -2 (x)    = 32 bytes
+//   -3 (y)    = 32 bytes
+func TestMakeCredential_COSEKeyShape(t *testing.T) {
+	verifier := &fakeVerifier{performsUV: true, nextResult: VerifyResult{OK: true}}
+	s := newTestServer(t, verifier, &fakePinentry{})
+
+	resp := &fakeResponder{}
+	payload := makeMakeCredCBOR(t, "cose-shape.example", "Shape", "user", false, false)
+	s.handleMakeCredential(context.Background(), resp, fidohid.AuthEvent{}, payload)
+	if resp.lastCtap2().status != ctap2.StatusOK {
+		t.Fatalf("status=0x%02x", resp.lastCtap2().status)
+	}
+
+	var top map[int]cbor.RawMessage
+	cbor.Unmarshal(resp.lastCtap2().data, &top)
+	var authData []byte
+	cbor.Unmarshal(top[2], &authData)
+	credIDLen := int(authData[32+1+4+16])<<8 | int(authData[32+1+4+16+1])
+	coseStart := 32 + 1 + 4 + 16 + 2 + credIDLen
+	coseBytes := authData[coseStart:]
+
+	var cose map[int]interface{}
+	if err := cbor.Unmarshal(coseBytes, &cose); err != nil {
+		t.Fatalf("decode cose key: %s", err)
+	}
+	if kty, _ := cose[1].(uint64); kty != 2 {
+		t.Errorf("kty = %v, want 2 (EC2)", cose[1])
+	}
+	if alg, _ := cose[3].(int64); alg != -7 {
+		t.Errorf("alg = %v, want -7 (ES256)", cose[3])
+	}
+	if crv, _ := cose[-1].(uint64); crv != 1 {
+		t.Errorf("crv = %v, want 1 (P-256)", cose[-1])
+	}
+	if x, _ := cose[-2].([]byte); len(x) != 32 {
+		t.Errorf("x len = %d, want 32", len(x))
+	}
+	if y, _ := cose[-3].([]byte); len(y) != 32 {
+		t.Errorf("y len = %d, want 32", len(y))
 	}
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -530,6 +530,225 @@ func TestGetAssertion_UserEntityUsesStringKeys(t *testing.T) {
 	}
 }
 
+// CTAP2 §6 mandates canonical CBOR encoding for all responses. The user
+// entity sub-map keys must be sorted (length-first or bytewise — both
+// produce id, name, displayName for these particular keys). Default
+// cbor.Marshal does NOT sort, so this test catches any regression that
+// removes the dedicated CTAP2EncOptions encoder.
+func TestGetAssertion_ResponseIsCanonicalCBOR(t *testing.T) {
+	verifier := &fakeVerifier{nextResult: VerifyResult{OK: true}}
+	s := newTestServer(t, verifier, &fakePinentry{})
+	registerCred(t, s, "canonical.example", "Canonical", "user", true)
+
+	resp := &fakeResponder{}
+	payload := makeAssertionCBOR(t, "canonical.example", nil, nil)
+	s.handleGetAssertion(context.Background(), resp, fidohid.AuthEvent{}, payload)
+
+	if resp.lastCtap2().status != ctap2.StatusOK {
+		t.Fatalf("status=0x%02x", resp.lastCtap2().status)
+	}
+	top := decodeAssertion(t, resp.lastCtap2().data)
+
+	// Top-level integer keys must be in ascending order.
+	rawTop := resp.lastCtap2().data
+	intOrder, err := readMapIntKeyOrder(rawTop)
+	if err != nil {
+		t.Fatalf("read top key order: %s", err)
+	}
+	for i := 1; i < len(intOrder); i++ {
+		if intOrder[i] < intOrder[i-1] {
+			t.Errorf("top-level keys not sorted ascending: %v", intOrder)
+			break
+		}
+	}
+
+	// User entity (field 4) sub-map keys must be sorted (CTAP2 bytewise lexical
+	// order of CBOR-encoded keys). For {"id","name","displayName"} that's id,
+	// name, displayName.
+	userBytes := top[4]
+	strOrder, err := readMapStringKeyOrder(userBytes)
+	if err != nil {
+		t.Fatalf("read user key order: %s", err)
+	}
+	want := []string{"id", "name", "displayName"}
+	if fmt.Sprintf("%v", strOrder) != fmt.Sprintf("%v", want) {
+		t.Errorf("user entity key order = %v, want %v (CTAP2 canonical)", strOrder, want)
+	}
+}
+
+// readMapIntKeyOrder walks the top-level map of a CBOR document and returns
+// the integer keys in the order they were emitted. Used to verify CTAP2
+// canonical encoding (sorted ascending).
+func readMapIntKeyOrder(b []byte) ([]int, error) {
+	dec := cbor.NewDecoder(bytes.NewReader(b))
+	var raw cbor.RawMessage
+	if err := dec.Decode(&raw); err != nil {
+		return nil, err
+	}
+	// Re-decode as ordered key-value pairs by reading element-by-element.
+	if len(raw) < 1 {
+		return nil, errors.New("empty cbor")
+	}
+	mt := raw[0] >> 5
+	if mt != 5 {
+		return nil, fmt.Errorf("not a map: major type %d", mt)
+	}
+	// Decode into a temporary structure that preserves order via cbor.RawTag-style
+	// trick: marshal/unmarshal through []cbor.RawMessage of pairs is complex, so
+	// instead use the slim approach of decoding into map and re-checking encoded
+	// bytes. For this test we walk the bytes manually.
+	pos := 1
+	count := int(raw[0] & 0x1f)
+	if count == 0x18 {
+		count = int(raw[1])
+		pos = 2
+	} else if count == 0x19 {
+		count = int(raw[1])<<8 | int(raw[2])
+		pos = 3
+	}
+	out := make([]int, 0, count)
+	for i := 0; i < count; i++ {
+		// Read int key
+		k, n, err := readInt(raw[pos:])
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, k)
+		pos += n
+		// Skip the value
+		vn, err := skipItem(raw[pos:])
+		if err != nil {
+			return nil, err
+		}
+		pos += vn
+	}
+	return out, nil
+}
+
+func readMapStringKeyOrder(raw []byte) ([]string, error) {
+	if len(raw) < 1 {
+		return nil, errors.New("empty cbor")
+	}
+	mt := raw[0] >> 5
+	if mt != 5 {
+		return nil, fmt.Errorf("not a map: major type %d", mt)
+	}
+	pos := 1
+	count := int(raw[0] & 0x1f)
+	if count == 0x18 {
+		count = int(raw[1])
+		pos = 2
+	}
+	out := make([]string, 0, count)
+	for i := 0; i < count; i++ {
+		// Read string key (major type 3)
+		if raw[pos]>>5 != 3 {
+			return nil, fmt.Errorf("expected string key, got major type %d", raw[pos]>>5)
+		}
+		slen := int(raw[pos] & 0x1f)
+		pos++
+		if slen == 0x18 {
+			slen = int(raw[pos])
+			pos++
+		}
+		out = append(out, string(raw[pos:pos+slen]))
+		pos += slen
+		// Skip value
+		vn, err := skipItem(raw[pos:])
+		if err != nil {
+			return nil, err
+		}
+		pos += vn
+	}
+	return out, nil
+}
+
+func readInt(b []byte) (int, int, error) {
+	if len(b) == 0 {
+		return 0, 0, errors.New("empty")
+	}
+	mt := b[0] >> 5
+	if mt != 0 && mt != 1 {
+		return 0, 0, fmt.Errorf("not an int: mt=%d", mt)
+	}
+	v := int(b[0] & 0x1f)
+	n := 1
+	if v == 0x18 {
+		v = int(b[1])
+		n = 2
+	} else if v == 0x19 {
+		v = int(b[1])<<8 | int(b[2])
+		n = 3
+	}
+	if mt == 1 {
+		v = -1 - v
+	}
+	return v, n, nil
+}
+
+// skipItem advances past one CBOR item and returns the bytes consumed.
+// Supports the small subset (ints, byte strings, text strings, arrays, maps,
+// floats, bool, null) needed by these tests.
+func skipItem(b []byte) (int, error) {
+	if len(b) == 0 {
+		return 0, errors.New("empty")
+	}
+	mt := b[0] >> 5
+	low := b[0] & 0x1f
+	pos := 1
+	var arg uint64
+	switch {
+	case low < 24:
+		arg = uint64(low)
+	case low == 24:
+		arg = uint64(b[pos])
+		pos++
+	case low == 25:
+		arg = uint64(b[pos])<<8 | uint64(b[pos+1])
+		pos += 2
+	case low == 26:
+		arg = uint64(b[pos])<<24 | uint64(b[pos+1])<<16 | uint64(b[pos+2])<<8 | uint64(b[pos+3])
+		pos += 4
+	case low == 27:
+		for i := 0; i < 8; i++ {
+			arg = arg<<8 | uint64(b[pos+i])
+		}
+		pos += 8
+	default:
+		return 0, fmt.Errorf("unsupported low %d", low)
+	}
+	switch mt {
+	case 0, 1, 7: // unsigned, negative, simple — done
+		return pos, nil
+	case 2, 3: // byte string, text string
+		return pos + int(arg), nil
+	case 4: // array
+		for i := uint64(0); i < arg; i++ {
+			n, err := skipItem(b[pos:])
+			if err != nil {
+				return 0, err
+			}
+			pos += n
+		}
+		return pos, nil
+	case 5: // map
+		for i := uint64(0); i < arg; i++ {
+			n, err := skipItem(b[pos:]) // key
+			if err != nil {
+				return 0, err
+			}
+			pos += n
+			n, err = skipItem(b[pos:]) // value
+			if err != nil {
+				return 0, err
+			}
+			pos += n
+		}
+		return pos, nil
+	}
+	return 0, fmt.Errorf("unsupported major type %d", mt)
+}
+
 // The signature in field 3 must verify against the assertion's authData ||
 // clientDataHash. Catches any change that breaks the signing input.
 func TestGetAssertion_SignatureCoversAuthDataAndClientDataHash(t *testing.T) {

--- a/main_test.go
+++ b/main_test.go
@@ -1634,12 +1634,44 @@ func TestGetAssertion_NoResidentCredentials(t *testing.T) {
 	}
 }
 
-// NOTE: ctap2.StatusUserActionTimeout in this codebase is defined as 0x2A,
-// but the FIDO/CTAP2 spec value (per libfido2 fido/err.h) is 0x2F. 0x2A is
-// actually FIDO_ERR_NO_OPERATION_PENDING. This is a pre-existing constant
-// bug in ctap2/ctap2.go, not in scope for this tests-only PR. The test pins
-// whatever value the constant currently has so a fix won't silently regress
-// the rest of the suite.
+// TestStatusCodeValuesMatchSpec asserts every CTAP2 status code constant in
+// ctap2/ctap2.go has the value defined by the spec. Source of truth: libfido2
+// src/fido/err.h, which is generated from the FIDO Alliance CTAP 2.1 spec
+// section 8.2 "Status codes".
+//
+// If you change a constant value in ctap2.go and didn't intend to break spec
+// compliance, this test catches it.
+func TestStatusCodeValuesMatchSpec(t *testing.T) {
+	cases := []struct {
+		name string
+		got  byte
+		want byte
+	}{
+		{"StatusOK", ctap2.StatusOK, 0x00},
+		{"StatusInvalidCbor", ctap2.StatusInvalidCbor, 0x12},
+		{"StatusCredentialExcluded", ctap2.StatusCredentialExcluded, 0x19},
+		{"StatusUnsupportedAlg", ctap2.StatusUnsupportedAlg, 0x26},
+		{"StatusOperationDenied", ctap2.StatusOperationDenied, 0x27},
+		{"StatusInvalidOption", ctap2.StatusInvalidOption, 0x2C},
+		{"StatusNoCredentials", ctap2.StatusNoCredentials, 0x2E},
+		// 0x2F per CTAP 2.1 §8.2 / FIDO_ERR_USER_ACTION_TIMEOUT.
+		// 0x2A is FIDO_ERR_NO_OPERATION_PENDING — a different error.
+		{"StatusUserActionTimeout", ctap2.StatusUserActionTimeout, 0x2F},
+		{"StatusNotAllowed", ctap2.StatusNotAllowed, 0x30},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.got != tc.want {
+				t.Errorf("ctap2.%s = 0x%02x, spec value is 0x%02x", tc.name, tc.got, tc.want)
+			}
+		})
+	}
+}
+
+// TestGetAssertion_VerifierTimeout asserts the handler reports the spec-correct
+// timeout error code (CTAP2_ERR_USER_ACTION_TIMEOUT = 0x2F) when the verifier
+// doesn't complete in time. Pinning the constant rather than the literal so
+// the failure message reads cleanly.
 func TestGetAssertion_VerifierTimeout(t *testing.T) {
 	verifier := &fakeVerifier{performsUV: true, nextResult: VerifyResult{OK: true}}
 	s := newTestServer(t, verifier, &fakePinentry{})

--- a/memory/memory.go
+++ b/memory/memory.go
@@ -85,10 +85,16 @@ func (m *Mem) SignASN1(keyHandle, applicationParam, digest []byte) ([]byte, erro
 		return nil, fmt.Errorf("open child private key err: %w", err)
 	}
 
-	var ecdsaKey ecdsa.PrivateKey
-
-	ecdsaKey.D = new(big.Int).SetBytes(childPrivateKey)
-	ecdsaKey.PublicKey.Curve = elliptic.P256()
+	// Reconstruct the full ecdsa.PrivateKey including the public key.
+	// Go ≥1.20's crypto/ecdsa.SignASN1 validates the curve point in
+	// pointFromAffine and panics on the zero point, so X/Y MUST be set —
+	// it's not optional even when only the private scalar is needed.
+	curve := elliptic.P256()
+	ecdsaKey := ecdsa.PrivateKey{
+		PublicKey: ecdsa.PublicKey{Curve: curve},
+		D:         new(big.Int).SetBytes(childPrivateKey),
+	}
+	ecdsaKey.PublicKey.X, ecdsaKey.PublicKey.Y = curve.ScalarBaseMult(childPrivateKey)
 
 	return ecdsa.SignASN1(rand.Reader, &ecdsaKey, digest)
 }

--- a/memory/memory_test.go
+++ b/memory/memory_test.go
@@ -1,0 +1,147 @@
+package memory
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"testing"
+)
+
+// TestRegisterSignVerifyRoundTrip is the spec-correct end-to-end check for the
+// in-memory backend: register a key for a site, sign a digest with the
+// returned key handle, then verify the signature against the public key the
+// register call returned. If the backend can't produce a verifiable signature,
+// nothing about it works.
+//
+// This test caught a pre-existing bug on Go ≥1.20 where SignASN1 was building
+// an ecdsa.PrivateKey without populating PublicKey.X/Y. crypto/ecdsa now
+// validates the curve point in SignASN1 and panics with x=y=0:
+//
+//	crypto/ecdsa.pointFromAffine: ... pointFromAffine(x=0, y=0) ...
+//
+// The fix: derive (X, Y) from the scalar D via curve.ScalarBaseMult(D.Bytes())
+// in SignASN1, the same way the curve point is computed in RegisterKey.
+func TestRegisterSignVerifyRoundTrip(t *testing.T) {
+	m, err := New()
+	if err != nil {
+		t.Fatalf("New: %s", err)
+	}
+
+	appParam := sha256.Sum256([]byte("https://example.com"))
+
+	// Step 1: register a fresh key.
+	keyHandle, x, y, err := m.RegisterKey(appParam[:])
+	if err != nil {
+		t.Fatalf("RegisterKey: %s", err)
+	}
+	if x == nil || y == nil {
+		t.Fatalf("RegisterKey returned nil pubkey coordinates")
+	}
+	if len(keyHandle) == 0 {
+		t.Fatalf("RegisterKey returned empty key handle")
+	}
+
+	// Step 2: sign a digest with that key handle.
+	digest := sha256.Sum256([]byte("message-to-sign"))
+	sig, err := m.SignASN1(keyHandle, appParam[:], digest[:])
+	if err != nil {
+		t.Fatalf("SignASN1: %s", err)
+	}
+	if len(sig) == 0 {
+		t.Fatalf("SignASN1 returned empty signature")
+	}
+
+	// Step 3: verify the signature with the public key from RegisterKey.
+	// If the backend's internal key derivation is wrong, this fails — the
+	// signature won't validate against the claimed public key.
+	pub := &ecdsa.PublicKey{Curve: elliptic.P256(), X: x, Y: y}
+	if !ecdsa.VerifyASN1(pub, digest[:], sig) {
+		t.Fatalf("signature did not verify against pubkey from RegisterKey")
+	}
+}
+
+// TestRegisterSignWithWrongAppParamFails: the application parameter is
+// authenticated by the AEAD wrap. Trying to unwrap with the wrong appParam
+// must fail (otherwise a credential could be used cross-origin).
+func TestRegisterSignWithWrongAppParamFails(t *testing.T) {
+	m, err := New()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	correctApp := sha256.Sum256([]byte("https://github.com"))
+	wrongApp := sha256.Sum256([]byte("https://attacker.example"))
+
+	keyHandle, _, _, err := m.RegisterKey(correctApp[:])
+	if err != nil {
+		t.Fatal(err)
+	}
+	digest := sha256.Sum256([]byte("anything"))
+
+	if _, err := m.SignASN1(keyHandle, wrongApp[:], digest[:]); err == nil {
+		t.Fatalf("SignASN1 with wrong appParam should fail (cross-origin protection)")
+	}
+}
+
+// TestSignWithMalformedKeyHandleFails: corrupted/short key handles must fail
+// the AEAD open, not panic.
+func TestSignWithMalformedKeyHandleFails(t *testing.T) {
+	m, err := New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	appParam := sha256.Sum256([]byte("x"))
+	digest := sha256.Sum256([]byte("y"))
+
+	// Too short to even contain the nonce.
+	if _, err := m.SignASN1([]byte("short"), appParam[:], digest[:]); err == nil {
+		t.Errorf("SignASN1 should reject too-short key handle")
+	}
+	// Right length-ish but garbage payload — AEAD open should fail.
+	garbage := make([]byte, 64)
+	if _, err := m.SignASN1(garbage, appParam[:], digest[:]); err == nil {
+		t.Errorf("SignASN1 should reject garbage key handle")
+	}
+}
+
+// TestCounterMonotonic: each call returns a value strictly greater than the
+// previous one. Required so signatures from a given credential can't be
+// replayed.
+func TestCounterMonotonic(t *testing.T) {
+	m, err := New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	prev := m.Counter()
+	for i := 0; i < 10; i++ {
+		next := m.Counter()
+		if next <= prev {
+			t.Errorf("counter went backwards: prev=%d next=%d", prev, next)
+		}
+		prev = next
+	}
+}
+
+// Sanity check on the math the SignASN1 fix relies on: D from a freshly-
+// generated P-256 key, multiplied by the curve's base point, produces a
+// valid non-zero point that is itself on the curve. This is the operation
+// the fix uses to recover (X, Y) from a stored scalar.
+func TestScalarBaseMultProducesValidPoint(t *testing.T) {
+	curve := elliptic.P256()
+	priv, err := ecdsa.GenerateKey(curve, rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	x, y := curve.ScalarBaseMult(priv.D.Bytes())
+	if x == nil || y == nil || x.Sign() == 0 || y.Sign() == 0 {
+		t.Errorf("ScalarBaseMult produced invalid point: x=%v y=%v", x, y)
+	}
+	if !curve.IsOnCurve(x, y) {
+		t.Errorf("derived point is not on P-256")
+	}
+	// And the recovered point must match the public key from GenerateKey.
+	if x.Cmp(priv.PublicKey.X) != 0 || y.Cmp(priv.PublicKey.Y) != 0 {
+		t.Errorf("ScalarBaseMult result does not match GenerateKey's public key")
+	}
+}


### PR DESCRIPTION
**Merge this first.** Three CTAP2 / runtime fixes, each pinned by a load-bearing test (verified by reverting individually and watching the test fail).

## Fixes

| Fix | Catching test |
|---|---|
| fprintd: subscribe to `VerifyStatus` **before** `VerifyStart`, scope match by sender + object path, guard malformed signal bodies | `TestProcessVerifyStatus/empty_body` panics without the guard |
| main.go: route all CTAP2 marshalling through `cbor.CTAP2EncOptions()` | `TestGetAssertion_ResponseIsCanonicalCBOR` fails on default `cbor.Marshal` |
| `ctap2.StatusUserActionTimeout`: `0x2A` → `0x2F` | `TestStatusCodeValuesMatchSpec/StatusUserActionTimeout` fails on `0x2A` |
| `memory.SignASN1`: derive `(X,Y)` from `D` via `curve.ScalarBaseMult` | `TestRegisterSignVerifyRoundTrip` panics at `pointFromAffine(x=0, y=0)` |

Cherry-picked from #22, dropping its buggy parts (nil-pointer `Options.UV` check, user-entity int-key schema, U2F `handleAuthenticate` verifier swap that loses pinentry dedup).

## Spec citations

- **CTAP 2.1 §8.2**: `0x2F` is the spec value for `CTAP2_ERR_USER_ACTION_TIMEOUT`. `0x2A` is **undefined** in the spec (gap between `0x28` and `0x2B`).
- **CTAP 2.1 §8**: canonical CBOR is mandatory; spec-strict decoders MUST reject non-canonical responses. Default `cbor.Marshal` empirically emits GetAssertion top keys as `[2 3 4 1]`.
- **libfido2 `cbor_decode_user`**: `PublicKeyCredentialUserEntity` uses string keys (`id`, `name`, `displayName`).

## Tests

`bbc50be` adds 11 new test functions (~17 sub-cases) including `TestCTAP2Enc_SortsMapKeys` (3 sub-cases — the strong unit test of the encoder itself).

| Package | Tests |
|---|---|
| `linux-id` | 36 |
| `linux-id/fprintd` | 2 (12 sub-cases) |
| `linux-id/memory` | 5 |

## CI matrix verified locally

```
go vet ./...
go test -race -count=1 -timeout 60s ./...
GOOS=linux GOARCH=386  go test  -count=1 -timeout 60s ./...
GOOS=linux GOARCH=arm GOARM=5 go build -v ./...
```

The install.sh + AUR-aligned systemd user unit changes go in #28 — independent, but slated to merge after this one.
