### PR TITLE
fix(fidohid): set uniq to ASCII string to prevent udev rule failure

### DIFF
--- a/fidohid/fidohid.go
+++ b/fidohid/fidohid.go
@@ -21,6 +21,7 @@ func New(ctx context.Context, name string) (*SoftToken, error) {
 	d.Data.Bus = busUSB
 	d.Data.VendorID = vendorID
 	d.Data.ProductID = productID
+	d.SetUniq("linux-id")
 
 	evtChan, err := d.Open(ctx)
 	if err != nil {


### PR DESCRIPTION
psanford/uhid fills the uniq field with 64 random bytes when unset. Binary garbage in HID_UNIQ causes 90-brltty-hid.rules to abort the entire udev transaction for the hidraw device, so fido_id never runs, ID_SECURITY_TOKEN is never set, and uaccess is never granted — leaving /dev/hidraw* inaccessible to the logged-in user.

I'm confused about why this wasn't a problem before? Did psanford/uhid change something? Did systemd? Did Arch?

Digging this out was stupidly deep. Thanks to Claude for the heavy lifting.

Fixes https://github.com/matejsmycka/linux-id/issues/31